### PR TITLE
Timer unscheduling and concurrency fixes, reminder updates

### DIFF
--- a/ModCore/Commands/Main.cs
+++ b/ModCore/Commands/Main.cs
@@ -444,9 +444,6 @@ namespace ModCore.Commands
             var now = DateTimeOffset.UtcNow;
             var dispatch_at = now + ts;
 
-            // lock the timers
-            await this.Shared.TimerSempahore.WaitAsync();
-
             var reminder = new DatabaseTimer
             {
                 GuildId = (long)ctx.Guild.Id,
@@ -456,22 +453,14 @@ namespace ModCore.Commands
                 ActionType = TimerActionType.Unban
             };
             reminder.SetData(new TimerUnbanData { Discriminator = m.Discriminator, DisplayName = m.Username, UserId = (long)m.Id });
-            var db = this.Database.CreateContext();
-            db.Timers.Add(reminder);
-            await db.SaveChangesAsync();
-
-            if (this.Shared.TimerData == null || this.Shared.TimerData.DispatchTime >= dispatch_at)
+            using (var db = this.Database.CreateContext())
             {
-                var tdata = this.Shared.TimerData;
-                tdata?.Cancel?.Cancel();
-
-                var cts = new CancellationTokenSource();
-                var t = Task.Delay(reminder.DispatchAt - DateTimeOffset.UtcNow, cts.Token);
-                tdata = new TimerData(t, reminder, ctx.Client, this.Database, this.Shared, cts);
-                _ = t.ContinueWith(Timers.TimerCallback, tdata, TaskContinuationOptions.OnlyOnRanToCompletion);
-                this.Shared.TimerData = tdata;
+                db.Timers.Add(reminder);
+                await db.SaveChangesAsync();
             }
-            this.Shared.TimerSempahore.Release();
+
+            Timers.RescheduleTimers(ctx.Client, this.Database, this.Shared);
+
             // End of Timer adding
             await ctx.RespondAsync($"Tempbanned user {m.DisplayName} (ID:{m.Id}) to be unbanned in {ts.Humanize(4, minUnit: TimeUnit.Second)}");
 
@@ -509,9 +498,6 @@ namespace ModCore.Commands
             var now = DateTimeOffset.UtcNow;
             var dispatch_at = now + ts;
 
-            // lock the timers
-            await this.Shared.TimerSempahore.WaitAsync();
-
             var reminder = new DatabaseTimer
             {
                 GuildId = (long)ctx.Guild.Id,
@@ -521,22 +507,14 @@ namespace ModCore.Commands
                 ActionType = TimerActionType.Unmute
             };
             reminder.SetData(new TimerUnmuteData { Discriminator = m.Discriminator, DisplayName = m.Username, UserId = (long)m.Id, MuteRoleId = (long)ctx.GetGuildSettings().MuteRoleId });
-            var db = this.Database.CreateContext();
-            db.Timers.Add(reminder);
-            await db.SaveChangesAsync();
-
-            if (this.Shared.TimerData == null || this.Shared.TimerData.DispatchTime >= dispatch_at)
+            using (var db = this.Database.CreateContext())
             {
-                var tdata = this.Shared.TimerData;
-                tdata?.Cancel?.Cancel();
-
-                var cts = new CancellationTokenSource();
-                var t = Task.Delay(reminder.DispatchAt - DateTimeOffset.UtcNow, cts.Token);
-                tdata = new TimerData(t, reminder, ctx.Client, this.Database, this.Shared, cts);
-                _ = t.ContinueWith(Timers.TimerCallback, tdata, TaskContinuationOptions.OnlyOnRanToCompletion);
-                this.Shared.TimerData = tdata;
+                db.Timers.Add(reminder);
+                await db.SaveChangesAsync();
             }
-            this.Shared.TimerSempahore.Release();
+
+            Timers.RescheduleTimers(ctx.Client, this.Database, this.Shared);
+            
             // End of Timer adding
             await ctx.RespondAsync($"Tempmuted user {m.DisplayName} (ID:{m.Id}) to be unmuted in {ts.Humanize(4, minUnit: TimeUnit.Second)}");
 
@@ -550,9 +528,6 @@ namespace ModCore.Commands
             var now = DateTimeOffset.UtcNow;
             var dispatch_at = now + pinfrom;
 
-            // lock the timers
-            await this.Shared.TimerSempahore.WaitAsync();
-
             var reminder = new DatabaseTimer
             {
                 GuildId = (long)ctx.Guild.Id,
@@ -562,22 +537,14 @@ namespace ModCore.Commands
                 ActionType = TimerActionType.Pin
             };
             reminder.SetData(new TimerPinData { MessageId = (long)message.Id, ChannelId = (long)ctx.Channel.Id });
-            var db = this.Database.CreateContext();
-            db.Timers.Add(reminder);
-            await db.SaveChangesAsync();
-
-            if (this.Shared.TimerData == null || this.Shared.TimerData.DispatchTime >= dispatch_at)
+            using (var db = this.Database.CreateContext())
             {
-                var tdata = this.Shared.TimerData;
-                tdata?.Cancel?.Cancel();
-
-                var cts = new CancellationTokenSource();
-                var t = Task.Delay(reminder.DispatchAt - DateTimeOffset.UtcNow, cts.Token);
-                tdata = new TimerData(t, reminder, ctx.Client, this.Database, this.Shared, cts);
-                _ = t.ContinueWith(Timers.TimerCallback, tdata, TaskContinuationOptions.OnlyOnRanToCompletion);
-                this.Shared.TimerData = tdata;
+                db.Timers.Add(reminder);
+                await db.SaveChangesAsync();
             }
-            this.Shared.TimerSempahore.Release();
+
+            Timers.RescheduleTimers(ctx.Client, this.Database, this.Shared);
+
             // End of Timer adding
             await ctx.RespondAsync($"After {pinfrom.Humanize(4, minUnit: TimeUnit.Second)} this message will be pinned");
         }
@@ -591,9 +558,6 @@ namespace ModCore.Commands
             var now = DateTimeOffset.UtcNow;
             var dispatch_at = now + pinuntil;
 
-            // lock the timers
-            await this.Shared.TimerSempahore.WaitAsync();
-
             var reminder = new DatabaseTimer
             {
                 GuildId = (long)ctx.Guild.Id,
@@ -603,22 +567,14 @@ namespace ModCore.Commands
                 ActionType = TimerActionType.Unpin
             };
             reminder.SetData(new TimerUnpinData { MessageId = (long)message.Id, ChannelId = (long)ctx.Channel.Id });
-            var db = this.Database.CreateContext();
-            db.Timers.Add(reminder);
-            await db.SaveChangesAsync();
-
-            if (this.Shared.TimerData == null || this.Shared.TimerData.DispatchTime >= dispatch_at)
+            using (var db = this.Database.CreateContext())
             {
-                var tdata = this.Shared.TimerData;
-                tdata?.Cancel?.Cancel();
-
-                var cts = new CancellationTokenSource();
-                var t = Task.Delay(reminder.DispatchAt - DateTimeOffset.UtcNow, cts.Token);
-                tdata = new TimerData(t, reminder, ctx.Client, this.Database, this.Shared, cts);
-                _ = t.ContinueWith(Timers.TimerCallback, tdata, TaskContinuationOptions.OnlyOnRanToCompletion);
-                this.Shared.TimerData = tdata;
+                db.Timers.Add(reminder);
+                await db.SaveChangesAsync();
             }
-            this.Shared.TimerSempahore.Release();
+
+            Timers.RescheduleTimers(ctx.Client, this.Database, this.Shared);
+
             // End of Timer adding
             await ctx.RespondAsync($"In {pinuntil.Humanize(4, minUnit: TimeUnit.Second)} this message will be unpinned.");
         }
@@ -651,7 +607,9 @@ namespace ModCore.Commands
         [Command("giverole"), Aliases("give", "gr"), Description("Gives the user a specified role"), RequireBotPermissions(Permissions.ManageRoles)]
         public async Task GiveRoleAsync(CommandContext ctx, [RemainingText]DiscordRole Role)
         {
-            var cfg = ctx.Guild.GetGuildSettings(Database.CreateContext());
+            GuildSettings cfg = null;
+            using (var db = Database.CreateContext())
+                cfg = ctx.Guild.GetGuildSettings(db);
             if (cfg.SelfRoles.Contains(Role.Id))
             {
                 if (ctx.Member.Roles.Any(x => x.Id == Role.Id))
@@ -676,7 +634,9 @@ namespace ModCore.Commands
         [Command("takerole"), Aliases("take", "tr"), Description("Takes a specified role away from the user"), RequireBotPermissions(Permissions.ManageRoles)]
         public async Task TakeRoleAsync(CommandContext ctx, [RemainingText]DiscordRole Role)
         {
-            var cfg = ctx.Guild.GetGuildSettings(Database.CreateContext());
+            GuildSettings cfg = null;
+            using (var db = Database.CreateContext())
+                cfg = ctx.Guild.GetGuildSettings(db);
             if (cfg.SelfRoles.Contains(Role.Id))
             {
                 if (!ctx.Member.Roles.Any(x => x.Id == Role.Id))

--- a/ModCore/Listeners/JoinLog.cs
+++ b/ModCore/Listeners/JoinLog.cs
@@ -19,7 +19,9 @@ namespace ModCore.Listeners
         [AsyncListener(EventTypes.GuildMemberAdded)]
         public static async Task LogNewMember(ModCoreShard bot, GuildMemberAddEventArgs e)
         {
-            var cfg = e.Guild.GetGuildSettings(bot.Database.CreateContext());
+            GuildSettings cfg = null;
+            using (var db = bot.Database.CreateContext())
+                cfg = e.Guild.GetGuildSettings(db);
             if (cfg.JoinLog.Enable)
             {
                 var m = e.Member;
@@ -46,7 +48,9 @@ namespace ModCore.Listeners
         [AsyncListener(EventTypes.GuildMemberRemoved)]
         public static async Task LogLeaveMember(ModCoreShard bot, GuildMemberRemoveEventArgs e)
         {
-            var cfg = e.Guild.GetGuildSettings(bot.Database.CreateContext());
+            GuildSettings cfg = null;
+            using (var db = bot.Database.CreateContext())
+                cfg = e.Guild.GetGuildSettings(db);
             if (cfg.JoinLog.Enable)
             {
                 var m = e.Member;

--- a/ModCore/Listeners/Linkfilter.cs
+++ b/ModCore/Listeners/Linkfilter.cs
@@ -28,9 +28,9 @@ namespace ModCore.Listeners
             if (e.Channel.Guild == null)
                 return;
 
-            var db = bot.Database.CreateContext();
-
-            var cfg = e.Guild.GetGuildSettings(db);
+            GuildSettings cfg = null;
+            using (var db = bot.Database.CreateContext())
+                cfg = e.Guild.GetGuildSettings(db);
             if (cfg == null)
                 return;
 

--- a/ModCore/Listeners/RoleState.cs
+++ b/ModCore/Listeners/RoleState.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using DSharpPlus;
 using DSharpPlus.EventArgs;
 using ModCore.Database;
+using ModCore.Entities;
 using ModCore.Logic;
 
 namespace ModCore.Listeners
@@ -12,51 +13,60 @@ namespace ModCore.Listeners
         [AsyncListener(EventTypes.GuildMemberRemoved)]
         public static async Task OnMemberLeave(ModCoreShard shard, GuildMemberRemoveEventArgs ea)
         {
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
-
-            if (ea.Member.Roles.Any()) // no roles or cache miss, but at this point little can be done about it
+            using (var db = shard.Database.CreateContext())
             {
-                var rsx = rs.IgnoredRoleIds;
-                var roles = ea.Member.Roles.Select(xr => xr.Id).Except(rsx).Select(xul => (long)xul);
+                var cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                var rs = cfg.RoleState;
 
-                var state = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
-                if (state == null) // no rolestate, create it
+                if (ea.Member.Roles.Any()) // no roles or cache miss, but at this point little can be done about it
                 {
-                    state = new DatabaseRolestateRoles
+                    var rsx = rs.IgnoredRoleIds;
+                    var roles = ea.Member.Roles.Select(xr => xr.Id).Except(rsx).Select(xul => (long)xul);
+
+                    var state = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
+                    if (state == null) // no rolestate, create it
                     {
-                        GuildId = (long)ea.Guild.Id,
-                        MemberId = (long)ea.Member.Id,
-                        RoleIds = roles.ToArray()
-                    };
-                    await db.RolestateRoles.AddAsync(state);
+                        state = new DatabaseRolestateRoles
+                        {
+                            GuildId = (long)ea.Guild.Id,
+                            MemberId = (long)ea.Member.Id,
+                            RoleIds = roles.ToArray()
+                        };
+                        await db.RolestateRoles.AddAsync(state);
+                    }
+                    else // rolestate exists, update it
+                    {
+                        state.RoleIds = roles.ToArray();
+                        db.RolestateRoles.Update(state);
+                    }
                 }
-                else // rolestate exists, update it
-                {
-                    state.RoleIds = roles.ToArray();
-                    db.RolestateRoles.Update(state);
-                }
-            }
 
-            // at this point, channel overrides do not exist
-            await db.SaveChangesAsync();
+                // at this point, channel overrides do not exist
+                await db.SaveChangesAsync();
+            }
         }
 
         [AsyncListener(EventTypes.GuildMemberAdded)]
         public static async Task OnMemberJoin(ModCoreShard shard, GuildMemberAddEventArgs ea)
         {
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
-
             var gld = ea.Guild;
-            var roleids = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
-            var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
+            GuildSettings cfg = null;
+            GuildRoleStateConfig rs = null;
+            DatabaseRolestateRoles roleids = null;
+            DatabaseRolestateOverride[] chperms = null;
+
+            using (var db = shard.Database.CreateContext())
+            {
+                cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                rs = cfg.RoleState;
+
+                roleids = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
+                chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id).ToArray();
+            }
 
             if (roleids != null)
             {
@@ -96,31 +106,33 @@ namespace ModCore.Listeners
         [AsyncListener(EventTypes.GuildMemberUpdated)]
         public static async Task OnMemberUpdate(ModCoreShard shard, GuildMemberUpdateEventArgs ea)
         {
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
-
-            var gld = ea.Guild;
-            var roleids = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
-
-            if (roleids == null)
+            using (var db = shard.Database.CreateContext())
             {
-                roleids = new DatabaseRolestateRoles
-                {
-                    GuildId = (long)ea.Guild.Id,
-                    MemberId = (long)ea.Member.Id
-                };
-            }
+                var cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                var rs = cfg.RoleState;
 
-            roleids.RoleIds = ea.RolesAfter
-                .Select(xr => xr.Id)
-                .Except(rs.IgnoredRoleIds)
-                .Select(xid => (long)xid)
-                .ToArray();
-            db.RolestateRoles.Update(roleids);
-            await db.SaveChangesAsync();
+                var gld = ea.Guild;
+                var roleids = db.RolestateRoles.SingleOrDefault(xs => xs.GuildId == (long)ea.Guild.Id && xs.MemberId == (long)ea.Member.Id);
+
+                if (roleids == null)
+                {
+                    roleids = new DatabaseRolestateRoles
+                    {
+                        GuildId = (long)ea.Guild.Id,
+                        MemberId = (long)ea.Member.Id
+                    };
+                }
+
+                roleids.RoleIds = ea.RolesAfter
+                    .Select(xr => xr.Id)
+                    .Except(rs.IgnoredRoleIds)
+                    .Select(xid => (long)xid)
+                    .ToArray();
+                db.RolestateRoles.Update(roleids);
+                await db.SaveChangesAsync();
+            }
         }
 
         [AsyncListener(EventTypes.ChannelDeleted)]
@@ -129,18 +141,20 @@ namespace ModCore.Listeners
             if (ea.Guild == null)
                 return;
 
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
-
-            var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.ChannelId == (long)ea.Channel.Id);
-
-            if (chperms.Any())
+            using (var db = shard.Database.CreateContext())
             {
-                db.RolestateOverrides.RemoveRange(chperms);
-                await db.SaveChangesAsync();
+                var cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                var rs = cfg.RoleState;
+
+                var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.ChannelId == (long)ea.Channel.Id);
+
+                if (chperms.Any())
+                {
+                    db.RolestateOverrides.RemoveRange(chperms);
+                    await db.SaveChangesAsync();
+                }
             }
         }
 
@@ -162,123 +176,127 @@ namespace ModCore.Listeners
             if (ea.Guild == null)
                 return;
 
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
+            using (var db = shard.Database.CreateContext())
+            {
+                var cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                var rs = cfg.RoleState;
 
-            if (rs.IgnoredChannelIds.Contains(ea.ChannelAfter.Id))
-                return;
+                if (rs.IgnoredChannelIds.Contains(ea.ChannelAfter.Id))
+                    return;
 
-            var os = ea.ChannelAfter.PermissionOverwrites.Where(xo => xo.Type == "member").ToDictionary(xo => (long)xo.Id, xo => xo);
-            var osids = os.Select(xo => xo.Key).ToArray();
+                var os = ea.ChannelAfter.PermissionOverwrites.Where(xo => xo.Type == "member").ToDictionary(xo => (long)xo.Id, xo => xo);
+                var osids = os.Select(xo => xo.Key).ToArray();
 
-            var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.ChannelId == (long)ea.ChannelAfter.Id)
-                .ToDictionary(xs => xs.MemberId, xs => xs);
-            var permids = chperms.Select(xo => xo.Key).ToArray();
+                var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id && xs.ChannelId == (long)ea.ChannelAfter.Id)
+                    .ToDictionary(xs => xs.MemberId, xs => xs);
+                var permids = chperms.Select(xo => xo.Key).ToArray();
 
-            var del = permids.Except(osids);
-            var add = osids.Except(permids);
-            var mod = osids.Intersect(permids);
+                var del = permids.Except(osids);
+                var add = osids.Except(permids);
+                var mod = osids.Intersect(permids);
 
-            if (del.Any())
-                db.RolestateOverrides.RemoveRange(del.Select(xid => chperms[xid]));
+                if (del.Any())
+                    db.RolestateOverrides.RemoveRange(del.Select(xid => chperms[xid]));
 
-            if (add.Any())
-                await db.RolestateOverrides.AddRangeAsync(add.Select(xid => new DatabaseRolestateOverride
-                {
-                    ChannelId = (long)ea.ChannelAfter.Id,
-                    GuildId = (long)ea.Guild.Id,
-                    MemberId = xid,
-                    PermsAllow = (long)os[xid].Allow,
-                    PermsDeny = (long)os[xid].Deny
-                }));
+                if (add.Any())
+                    await db.RolestateOverrides.AddRangeAsync(add.Select(xid => new DatabaseRolestateOverride
+                    {
+                        ChannelId = (long)ea.ChannelAfter.Id,
+                        GuildId = (long)ea.Guild.Id,
+                        MemberId = xid,
+                        PermsAllow = (long)os[xid].Allow,
+                        PermsDeny = (long)os[xid].Deny
+                    }));
 
-            if (mod.Any())
-                foreach (var xid in mod)
-                {
-                    chperms[xid].PermsAllow = (long)os[xid].Allow;
-                    chperms[xid].PermsDeny = (long)os[xid].Deny;
+                if (mod.Any())
+                    foreach (var xid in mod)
+                    {
+                        chperms[xid].PermsAllow = (long)os[xid].Allow;
+                        chperms[xid].PermsDeny = (long)os[xid].Deny;
 
-                    db.RolestateOverrides.Update(chperms[xid]);
-                }
+                        db.RolestateOverrides.Update(chperms[xid]);
+                    }
 
-            if (del.Any() || add.Any() || mod.Any())
-                await db.SaveChangesAsync();
+                if (del.Any() || add.Any() || mod.Any())
+                    await db.SaveChangesAsync();
+            }
         }
 
         [AsyncListener(EventTypes.GuildAvailable)]
         public static async Task OnGuildAvailable(ModCoreShard shard, GuildCreateEventArgs ea)
         {
-            var db = shard.Database.CreateContext();
-            var cfg = ea.Guild.GetGuildSettings(db);
-            if (cfg == null || !cfg.RoleState.Enable)
-                return;
-            var rs = cfg.RoleState;
-
-            var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id);
-            var prms = chperms.GroupBy(xs => xs.ChannelId).ToDictionary(xg => xg.Key, xg => xg.ToDictionary(xs => xs.MemberId, xs => xs));
-            var any = false;
-
-            foreach (var chn in ea.Guild.Channels)
+            using (var db = shard.Database.CreateContext())
             {
-                if (rs.IgnoredChannelIds.Contains(chn.Id))
-                    continue;
+                var cfg = ea.Guild.GetGuildSettings(db);
+                if (cfg == null || !cfg.RoleState.Enable)
+                    return;
+                var rs = cfg.RoleState;
 
-                if (!prms.ContainsKey((long)chn.Id))
+                var chperms = db.RolestateOverrides.Where(xs => xs.GuildId == (long)ea.Guild.Id);
+                var prms = chperms.GroupBy(xs => xs.ChannelId).ToDictionary(xg => xg.Key, xg => xg.ToDictionary(xs => xs.MemberId, xs => xs));
+                var any = false;
+
+                foreach (var chn in ea.Guild.Channels)
                 {
-                    any = true;
-
-                    var os = chn.PermissionOverwrites.Where(xo => xo.Type == "member");
-                    if (!os.Any())
+                    if (rs.IgnoredChannelIds.Contains(chn.Id))
                         continue;
 
-                    await db.RolestateOverrides.AddRangeAsync(os.Select(xo => new DatabaseRolestateOverride
+                    if (!prms.ContainsKey((long)chn.Id))
                     {
-                        ChannelId = (long)chn.Id,
-                        GuildId = (long)chn.Guild.Id,
-                        MemberId = (long)xo.Id,
-                        PermsAllow = (long)xo.Allow,
-                        PermsDeny = (long)xo.Deny
-                    }));
-                }
-                else
-                {
-                    var cps = prms[(long)chn.Id];
-                    var os = chn.PermissionOverwrites.Where(xo => xo.Type == "member").ToDictionary(xo => (long)xo.Id, xo => xo);
-                    var osids = os.Keys.ToArray();
+                        any = true;
 
-                    var del = cps.Keys.Except(osids);
-                    var add = osids.Except(cps.Keys);
-                    var mod = osids.Intersect(cps.Keys);
+                        var os = chn.PermissionOverwrites.Where(xo => xo.Type == "member");
+                        if (!os.Any())
+                            continue;
 
-                    if (any |= del.Any())
-                        db.RolestateOverrides.RemoveRange(del.Select(xid => cps[xid]));
-
-                    if (any |= add.Any())
-                        await db.RolestateOverrides.AddRangeAsync(add.Select(xid => new DatabaseRolestateOverride
+                        await db.RolestateOverrides.AddRangeAsync(os.Select(xo => new DatabaseRolestateOverride
                         {
                             ChannelId = (long)chn.Id,
-                            GuildId = (long)ea.Guild.Id,
-                            MemberId = xid,
-                            PermsAllow = (long)os[xid].Allow,
-                            PermsDeny = (long)os[xid].Deny
+                            GuildId = (long)chn.Guild.Id,
+                            MemberId = (long)xo.Id,
+                            PermsAllow = (long)xo.Allow,
+                            PermsDeny = (long)xo.Deny
                         }));
+                    }
+                    else
+                    {
+                        var cps = prms[(long)chn.Id];
+                        var os = chn.PermissionOverwrites.Where(xo => xo.Type == "member").ToDictionary(xo => (long)xo.Id, xo => xo);
+                        var osids = os.Keys.ToArray();
 
-                    if (any |= mod.Any())
-                        foreach (var xid in mod)
-                        {
-                            cps[xid].PermsAllow = (long)os[xid].Allow;
-                            cps[xid].PermsDeny = (long)os[xid].Deny;
+                        var del = cps.Keys.Except(osids);
+                        var add = osids.Except(cps.Keys);
+                        var mod = osids.Intersect(cps.Keys);
 
-                            db.RolestateOverrides.Update(cps[xid]);
-                        }
+                        if (any |= del.Any())
+                            db.RolestateOverrides.RemoveRange(del.Select(xid => cps[xid]));
+
+                        if (any |= add.Any())
+                            await db.RolestateOverrides.AddRangeAsync(add.Select(xid => new DatabaseRolestateOverride
+                            {
+                                ChannelId = (long)chn.Id,
+                                GuildId = (long)ea.Guild.Id,
+                                MemberId = xid,
+                                PermsAllow = (long)os[xid].Allow,
+                                PermsDeny = (long)os[xid].Deny
+                            }));
+
+                        if (any |= mod.Any())
+                            foreach (var xid in mod)
+                            {
+                                cps[xid].PermsAllow = (long)os[xid].Allow;
+                                cps[xid].PermsDeny = (long)os[xid].Deny;
+
+                                db.RolestateOverrides.Update(cps[xid]);
+                            }
+                    }
                 }
-            }
 
-            if (any)
-                await db.SaveChangesAsync();
+                if (any)
+                    await db.SaveChangesAsync();
+            }
         }
 
         [AsyncListener(EventTypes.GuildCreated)]

--- a/ModCore/Listeners/Timers.cs
+++ b/ModCore/Listeners/Timers.cs
@@ -16,60 +16,71 @@ namespace ModCore.Listeners
         [AsyncListener(EventTypes.Ready)]
         public static async Task OnReady(ModCoreShard shard, ReadyEventArgs ea)
         {
-            var db = shard.Database.CreateContext();
-            if (!db.Timers.Any())
-                return;
-
-            var ids = ea.Client.Guilds.Select(xg => (long)xg.Key).ToArray();
-            var timers = db.Timers.Where(xt => ids.Contains(xt.GuildId)).ToArray();
-            if (!timers.Any())
-                return;
-
-            // lock timers
-            await shard.ShardData.TimerSempahore.WaitAsync();
-
-            var now = DateTimeOffset.UtcNow;
-            var past = timers.Where(xt => xt.DispatchAt <= now.AddSeconds(30)).ToArray();
-            if (past.Any())
+            using (var db = shard.Database.CreateContext())
             {
-                foreach (var xt in past)
+                if (!db.Timers.Any())
+                    return;
+
+                var ids = ea.Client.Guilds.Select(xg => (long)xg.Key).ToArray();
+                var timers = db.Timers.Where(xt => ids.Contains(xt.GuildId)).ToArray();
+                if (!timers.Any())
+                    return;
+
+                // lock timers
+                await shard.ShardData.TimerSempahore.WaitAsync();
+
+                var now = DateTimeOffset.UtcNow;
+                var past = timers.Where(xt => xt.DispatchAt <= now.AddSeconds(30)).ToArray();
+                if (past.Any())
                 {
-                    // dispatch past timers
-                    _ = DispatchTimer(new TimerData(null, xt, shard.Client, shard.Database, shard.ShardData, null));
+                    foreach (var xt in past)
+                    {
+                        // dispatch past timers
+                        _ = DispatchTimer(new TimerData(null, xt, shard.Client, shard.Database, shard.ShardData, null));
+                    }
+
+                    db.Timers.RemoveRange(past);
+                    await db.SaveChangesAsync();
                 }
 
-                db.Timers.RemoveRange(past);
-                await db.SaveChangesAsync();
+                // unlock the timers
+                shard.ShardData.TimerSempahore.Release();
+
+                RescheduleTimers(shard.Client, shard.Database, shard.ShardData);
             }
-
-            // unlock the timers
-            shard.ShardData.TimerSempahore.Release();
-
-            RescheduleTimers(shard.Client, shard.Database, shard.ShardData);
         }
 
         public static void TimerCallback(Task t, object state)
         {
             var tdata = state as TimerData;
             var shard = tdata.Context;
-            var db = tdata.Database.CreateContext();
+            var shared = tdata.Shared;
+
+            // lock the timers
+            shared.TimerSempahore.Wait();
 
             // remove the timer
-            db.Timers.Remove(tdata.DbTimer);
-            db.SaveChanges();
-            tdata.Shared.TimerData = null;
+            using (var db = tdata.Database.CreateContext())
+            {
+                db.Timers.Remove(tdata.DbTimer);
+                db.SaveChanges();
+                tdata.Shared.TimerData = null;
+            }
 
-            // dispatch it
+            // release the lock
+            shared.TimerSempahore.Release();
+
+            // dispatch the timer
             _ = Task.Run(LocalDispatch);
 
             // schedule new one
             RescheduleTimers(shard, tdata.Database, tdata.Shared);
 
-            Task LocalDispatch() =>
-                DispatchTimer(tdata);
+            Task LocalDispatch()
+                => DispatchTimer(tdata);
         }
 
-        public static async Task DispatchTimer(TimerData tdata)
+        private static async Task DispatchTimer(TimerData tdata)
         {
             var timer = tdata.DbTimer;
             var client = tdata.Context;
@@ -94,16 +105,18 @@ namespace ModCore.Listeners
                 var data = timer.GetData<TimerUnbanData>();
                 if (client.Guilds.Any(x => x.Key == (ulong)timer.GuildId))
                 {
-                    var db = tdata.Database.CreateContext();
-                    var Guild = client.Guilds[(ulong)timer.GuildId];
-                    try
+                    using (var db = tdata.Database.CreateContext())
                     {
-                        await Guild.UnbanMemberAsync((ulong)data.UserId);
-                    }
-                    catch (Exception) { }
+                        var Guild = client.Guilds[(ulong)timer.GuildId];
+                        try
+                        {
+                            await Guild.UnbanMemberAsync((ulong)data.UserId);
+                        }
+                        catch (Exception) { }
 
-                    var settings = Guild.GetGuildSettings(db);
-                    await client.LogAutoActionAsync(Guild, db, $"Member unbanned: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})");
+                        var settings = Guild.GetGuildSettings(db);
+                        await client.LogAutoActionAsync(Guild, db, $"Member unbanned: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})");
+                    }
                 }
             }
             else if (timer.ActionType == TimerActionType.Unmute)
@@ -111,41 +124,45 @@ namespace ModCore.Listeners
                 var data = timer.GetData<TimerUnmuteData>();
                 if (client.Guilds.Any(x => x.Key == (ulong)timer.GuildId))
                 {
-                    var db = tdata.Database.CreateContext();
-                    var Guild = client.Guilds[(ulong)timer.GuildId];
-                    var Member = await Guild.GetMemberAsync((ulong)data.UserId);
-                    var Role = (DiscordRole)null;
-                    try
+                    using (var db = tdata.Database.CreateContext())
                     {
-                        Role = Guild.GetRole((ulong)data.MuteRoleId);
-                    }
-                    catch (Exception)
-                    {
+                        var Guild = client.Guilds[(ulong)timer.GuildId];
+                        var Member = await Guild.GetMemberAsync((ulong)data.UserId);
+                        var Role = (DiscordRole)null;
                         try
                         {
-                            Role = Guild.GetRole(Guild.GetGuildSettings(db).MuteRoleId);
+                            Role = Guild.GetRole((ulong)data.MuteRoleId);
                         }
                         catch (Exception)
                         {
-                            await client.LogAutoActionAsync(Guild, db, $"**[IMPORTANT]**\nFailed to unmute member: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})\nMute role does not exist!");
-                            return;
+                            try
+                            {
+                                Role = Guild.GetRole(Guild.GetGuildSettings(db).MuteRoleId);
+                            }
+                            catch (Exception)
+                            {
+                                await client.LogAutoActionAsync(Guild, db, $"**[IMPORTANT]**\nFailed to unmute member: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})\nMute role does not exist!");
+                                return;
+                            }
                         }
+                        await Guild.RevokeRoleAsync(Member, Role, "");
+                        await client.LogAutoActionAsync(Guild, db, $"Member unmuted: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})");
                     }
-                    await Guild.RevokeRoleAsync(Member, Role, "");
-                    await client.LogAutoActionAsync(Guild, db, $"Member unmuted: {data.DisplayName}#{data.Discriminator} (ID: {data.UserId})");
                 }
             }
-            else if(timer.ActionType == TimerActionType.Pin)
+            else if (timer.ActionType == TimerActionType.Pin)
             {
                 var data = timer.GetData<TimerPinData>();
                 if (client.Guilds.Any(x => x.Key == (ulong)timer.GuildId))
                 {
-                    var db = tdata.Database.CreateContext();
-                    var Guild = client.Guilds[(ulong)timer.GuildId];
-                    var Channel = Guild.GetChannel((ulong)data.ChannelId);
-                    var Message = await Channel.GetMessageAsync((ulong)data.MessageId);
-                    await Message.PinAsync();
-                    await client.LogAutoActionAsync(Guild, db, $"Scheduled pin: Message with ID: {data.MessageId} in Channel #{Channel.Name} ({Channel.Id})");
+                    using (var db = tdata.Database.CreateContext())
+                    {
+                        var Guild = client.Guilds[(ulong)timer.GuildId];
+                        var Channel = Guild.GetChannel((ulong)data.ChannelId);
+                        var Message = await Channel.GetMessageAsync((ulong)data.MessageId);
+                        await Message.PinAsync();
+                        await client.LogAutoActionAsync(Guild, db, $"Scheduled pin: Message with ID: {data.MessageId} in Channel #{Channel.Name} ({Channel.Id})");
+                    }
                 }
             }
             else if (timer.ActionType == TimerActionType.Unpin)
@@ -153,12 +170,14 @@ namespace ModCore.Listeners
                 var data = timer.GetData<TimerPinData>();
                 if (client.Guilds.Any(x => x.Key == (ulong)timer.GuildId))
                 {
-                    var db = tdata.Database.CreateContext();
-                    var Guild = client.Guilds[(ulong)timer.GuildId];
-                    var Channel = Guild.GetChannel((ulong)data.ChannelId);
-                    var Message = await Channel.GetMessageAsync((ulong)data.MessageId);
-                    await Message.UnpinAsync();
-                    await client.LogAutoActionAsync(Guild, db, $"Scheduled unpin: Message with ID: {data.MessageId} in Channel #{Channel.Name} ({Channel.Id})");
+                    using (var db = tdata.Database.CreateContext())
+                    {
+                        var Guild = client.Guilds[(ulong)timer.GuildId];
+                        var Channel = Guild.GetChannel((ulong)data.ChannelId);
+                        var Message = await Channel.GetMessageAsync((ulong)data.MessageId);
+                        await Message.UnpinAsync();
+                        await client.LogAutoActionAsync(Guild, db, $"Scheduled unpin: Message with ID: {data.MessageId} in Channel #{Channel.Name} ({Channel.Id})");
+                    }
                 }
             }
         }
@@ -169,20 +188,35 @@ namespace ModCore.Listeners
             shared.TimerSempahore.Wait();
 
             // set a new timer
-            var db = database.CreateContext();
-            var ids = client.Guilds.Select(xg => (long)xg.Key).ToArray();
-            var timers = db.Timers.Where(xt => ids.Contains(xt.GuildId))
-                .OrderBy(xt => xt.DispatchAt)
-                .ToArray();
+            DatabaseTimer[] timers = null;
+            bool force = false;
+            using (var db = database.CreateContext())
+            {
+                var ids = client.Guilds.Select(xg => (long)xg.Key).ToArray();
+                timers = db.Timers.Where(xt => ids.Contains(xt.GuildId))
+                    .OrderBy(xt => xt.DispatchAt)
+                    .ToArray();
+
+                if (shared.TimerData != null)
+                    force = db.Timers.Count(xt => xt.Id == shared.TimerData.DbTimer.Id) == 0; // .Any() throws
+            }
             var nearest = timers.FirstOrDefault();
             if (nearest == null)
             {
+                // there's no nearest timer
                 shared.TimerSempahore.Release();
                 return null;
             }
 
             var tdata = shared.TimerData;
-            if (CancelIfLaterThan(nearest.DispatchAt, shared))
+            if (tdata != null && tdata.DbTimer.Id == nearest.Id)
+            {
+                // it's the same timer
+                shared.TimerSempahore.Release();
+                return tdata;
+            }
+
+            if (CancelIfLaterThan(nearest.DispatchAt, shared, force))
             {
                 var cts = new CancellationTokenSource();
                 var t = Task.Delay(nearest.DispatchAt - DateTimeOffset.UtcNow, cts.Token);
@@ -197,10 +231,41 @@ namespace ModCore.Listeners
             return tdata;
         }
 
-        private static bool CancelIfLaterThan(DateTimeOffset dto, SharedData shared)
+        public static async Task<TimerData> UnscheduleTimerAsync(DatabaseTimer timer, DiscordClient shard, DatabaseContextBuilder database, SharedData shared)
+        {
+            // lock the timers
+            shared.TimerSempahore.Wait();
+
+            // remove the requested timer
+            using (var db = database.CreateContext())
+            {
+                db.Timers.Remove(timer);
+                await db.SaveChangesAsync();
+            }
+
+            // release the lock
+            shared.TimerSempahore.Release();
+
+            // trigger a reschedule
+            return RescheduleTimers(shard, database, shared);
+        }
+
+        public static DatabaseTimer FindNearestTimer(TimerActionType actionType, ulong userId, ulong channelId, ulong guildId, DatabaseContextBuilder database)
+        {
+            using (var db = database.CreateContext())
+                return db.Timers.FirstOrDefault(xt => xt.ActionType == actionType && xt.UserId == (long)userId && xt.ChannelId == (long)channelId && xt.GuildId == (long)guildId);
+        }
+
+        public static DatabaseTimer FindTimer(int id, TimerActionType actionType, ulong userId, DatabaseContextBuilder database)
+        {
+            using (var db = database.CreateContext())
+                return db.Timers.FirstOrDefault(xt => xt.Id == id && xt.ActionType == actionType && xt.UserId == (long)userId);
+        }
+
+        private static bool CancelIfLaterThan(DateTimeOffset dto, SharedData shared, bool force)
         {
             // check if a timer is going
-            if (shared.TimerData == null || shared.TimerData.DispatchTime >= dto)
+            if (force || shared.TimerData == null || shared.TimerData.DispatchTime >= dto)
             {
                 var xtdata = shared.TimerData;
                 xtdata?.Cancel?.Cancel();

--- a/ModCore/ModCore.csproj
+++ b/ModCore/ModCore.csproj
@@ -6,9 +6,10 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-beta-00341" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-beta-00341" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-beta-00341" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-beta-00344" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-beta-00344" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-beta-00344" />
+    <PackageReference Include="DSharpPlus.WebSocket.WebSocket4NetCore" Version="4.0.0-beta-00344" />
     <PackageReference Include="Humanizer.Core" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.0" />

--- a/ModCore/ModCoreShard.cs
+++ b/ModCore/ModCoreShard.cs
@@ -195,7 +195,9 @@ namespace ModCore
 
         public Task<int> GetPrefixPositionAsync(DiscordMessage msg)
         {
-            var cfg = msg.Channel.Guild.GetGuildSettings(Database.CreateContext());
+            GuildSettings cfg = null;
+            using (var db = Database.CreateContext())
+                cfg = msg.Channel.Guild.GetGuildSettings(db);
             if (cfg?.Prefix != null)
                 return Task.FromResult(msg.GetStringPrefixLength(cfg.Prefix));
 


### PR DESCRIPTION
This PR implements a way to query and unschedule timers. It also fixes a number of issues related to database concurrency in timers.

Furthermore, the reminder commands got a way to stop a reminder from happening. Some other database-reliant code also got quality pass.

Additionally, updated DSharpPlus 🤖.